### PR TITLE
Don't gloss over "This is unused" warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
-# E-Naught-2017
-Code for our 2017 robot, Epsilon Naught
-
+# Stratus-2017
+Code for our 2017 robot, Stratus

--- a/Stratus-2017/src/org/usfirst/frc/team1389/systems/OctoMecanumSystem.java
+++ b/Stratus-2017/src/org/usfirst/frc/team1389/systems/OctoMecanumSystem.java
@@ -30,6 +30,7 @@ public class OctoMecanumSystem extends Subsystem {
 	private VerifiedSwitcher octoShifter;
 	private DigitalIn switchModes;
 	private FourDriveOut<Percent> voltageDrive;
+	private FourDriveOut<Speed> speedDrive;
 	private RangeIn<Value> airPressure;
 
 	public OctoMecanumSystem(FourDriveOut<Percent> voltageDrive, FourDriveOut<Speed> speedDrive,
@@ -37,6 +38,9 @@ public class OctoMecanumSystem extends Subsystem {
 			PercentIn yAxis, PercentIn twist, PercentIn trim, DigitalIn switchModes, DigitalIn trigger) {
 		this.airPressure = airPressure;
 		this.voltageDrive = voltageDrive;
+		this.speedDrive = speedDrive;
+		this.octoShifter = octoShifter;
+		this.switchModes = switchModes;
 		setupTankDriveSystem(voltageDrive.getAsTank(), xAxis, yAxis, trim, trigger);
 		setupMecanumDriveSystem(voltageDrive, xAxis, yAxis, twist, trigger, gyro);
 	}


### PR DESCRIPTION
The code in `OctoMecanumSystem` was broken because [`octoShifter` the constructor parameter](https://github.com/team1389/Stratus-2017/blob/master/Stratus-2017/src/org/usfirst/frc/team1389/systems/OctoMecanumSystem.java#L36) wasn't being assigned to [`octoShifter` the private field](https://github.com/team1389/Stratus-2017/blob/master/Stratus-2017/src/org/usfirst/frc/team1389/systems/OctoMecanumSystem.java#L30).